### PR TITLE
CIDR support

### DIFF
--- a/cmd/oxdpus/add/add.go
+++ b/cmd/oxdpus/add/add.go
@@ -13,9 +13,11 @@ package add
 
 import (
 	"github.com/sematext/oxdpus/pkg/blacklist"
+	"github.com/sematext/oxdpus/pkg/iprange"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"net"
+	"strings"
 )
 
 func NewCommand(logger *logrus.Logger) *cobra.Command {
@@ -27,6 +29,21 @@ func NewCommand(logger *logrus.Logger) *cobra.Command {
 			m, err := blacklist.NewMap()
 			if err != nil {
 				logger.Fatal(err)
+			}
+			// IP range is specified in CIDR notation
+			if strings.Contains(ip, "/") {
+				addrs, err := iprange.FromCIDR(ip)
+				if err != nil {
+					logger.Fatal(err)
+				}
+				for _, addr := range addrs {
+					if m.Add(net.ParseIP(addr)); err != nil {
+						logger.Warnf("fail to add %s IP address to blacklist", addr)
+						continue
+					}
+				}
+				logger.Infof("%d addresses added to the blacklist", len(addrs))
+				return
 			}
 			if m.Add(net.ParseIP(ip)); err != nil {
 				logger.Error(err)

--- a/pkg/iprange/iprange.go
+++ b/pkg/iprange/iprange.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Sematext Group, Inc.
+ * All Rights Reserved
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF Sematext Group, Inc.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ */
+
+package iprange
+
+import "net"
+
+// FromCIDR returns all the IP address that pertain to the specified IP range.
+func FromCIDR(cidr string) ([]string, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]string, 0)
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); nextIP(ip) {
+		addrs = append(addrs, ip.String())
+	}
+	// remove network/broadcast addresses
+	return addrs[1 : len(addrs)-1], nil
+}
+
+func nextIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}

--- a/pkg/iprange/iprange_test.go
+++ b/pkg/iprange/iprange_test.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Sematext Group, Inc.
+ * All Rights Reserved
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF Sematext Group, Inc.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ */
+
+package iprange
+
+import (
+	"testing"
+)
+
+func TestFromCIDR(t *testing.T) {
+	addrs, err := FromCIDR("192.169.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 254 {
+		t.Fatalf("addrs should contain 254 but has %d addresses", len(addrs))
+	}
+}


### PR DESCRIPTION
This PR adds support for adding blocked IP addresses via CIDR notation. Example_

```
sudo ./cmd/oxdpus/oxdpus add --ip=192.169.1.0/24
INFO 254 addresses added to the blacklist
```